### PR TITLE
Refactor exceptions

### DIFF
--- a/nzbhydra/exceptions.py
+++ b/nzbhydra/exceptions.py
@@ -1,68 +1,55 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
-from builtins import super
-from future import standard_library
-
-#standard_library.install_aliases()
-from builtins import *
-
-
 class NzbHydraException(Exception):
-    def __init__(self, message=None, exception=None):
-        super(NzbHydraException, self).__init__(message)
+    pass
 
 
 class ExternalApiInfoException(NzbHydraException):
-    # An error occurred while contacting an external info API (tvdaze, omdbapi, etc) or parsing its returned data
-    def __init__(self, message):
-        super(NzbHydraException, self).__init__(message)
-        self.message = message
+    """An error occurred while contacting an external info API
+    (tvdaze, omdbapi, etc) or parsing its returned data.
+    """
+    pass
 
 
-class IndexerIllegalSearchException(NzbHydraException):
-    # Thrown if an internal sanity check fails, for example if we tried to execute an id based search on a indexer that doesn't support it
+class IndexerException(NzbHydraException):
     def __init__(self, message, search_module):
-        super(NzbHydraException, self).__init__(message)
-        self.message = message
+        super(IndexerException, self).__init__(message)
         self.search_module = search_module
 
 
-class IndexerAuthException(NzbHydraException):
-    # The indexer indicated that the authentication failed. This indexer should not be user until the problem is solved.
-    def __init__(self, message, search_module):
-        super(NzbHydraException, self).__init__(message)
-        self.message = message
-        self.search_module = search_module
+class IndexerIllegalSearchException(IndexerException):
+    """Thrown if an internal sanity check fails, for example if we tried
+    to execute an id based search on a indexer that doesn't support it.
+    """
+    pass
 
 
-class IndexerAccessException(NzbHydraException):
-    # The connection to the indexer was successful but we got an error page. We should probably wait some time until we use it again but don't assume it's a permanent problem
-    def __init__(self, message, search_module):
-        super(NzbHydraException, self).__init__(message)
-        self.message = message
-        self.search_module = search_module
+class IndexerAuthException(IndexerException):
+    """The indexer indicated that the authentication failed.
+    This indexer should not be used until the problem is solved.
+    """
+    pass
 
 
-class IndexerConnectionException(NzbHydraException):
-    # The connection to the indexer failed. We should probably wait some time until we use it again but don't assume it's a permanent problem
-    def __init__(self, message, search_module):
-        super(NzbHydraException, self).__init__(message)
-        self.message = message
-        self.search_module = search_module
+class IndexerAccessException(IndexerException):
+    """The connection to the indexer was successful but we got an error page.
+    We should probably wait some time until we use it again
+    but don't assume it's a permanent problem.
+    """
+    pass
 
 
-class IndexerResultParsingException(NzbHydraException):
-    # The connection to the indexer was successful but we were unable to parse the returned results
-    def __init__(self, message, search_module):
-        super(NzbHydraException, self).__init__(message)
-        self.message = message
-        self.search_module = search_module
+class IndexerConnectionException(IndexerException):
+    """The connection to the indexer failed. We should probably wait some time
+    until we use it again but don't assume it's a permanent problem.
+    """
+    pass
+
+
+class IndexerResultParsingException(IndexerException):
+    """The connection to the indexer was successful
+    but we were unable to parse the returned results.
+    """
+    pass
 
 
 class DownloaderException(NzbHydraException):
-    def __init__(self, message):
-        super(NzbHydraException, self).__init__(message)
-        self.message = message
+    pass


### PR DESCRIPTION
Use inheritance instead of explicitly implementing the init method.
All Indexer*Exceptions now inherit from a new IndexerException base class.

Also removed the unused imports and the second argument from NzbHydraException (never used).