### PR TITLE
add explicit message attribute to NzbHydraException

### DIFF
--- a/nzbhydra/exceptions.py
+++ b/nzbhydra/exceptions.py
@@ -1,5 +1,7 @@
 class NzbHydraException(Exception):
-    pass
+    def __init__(self, message=""):
+        super(NzbHydraException, self).__init__()
+        self.message = message
 
 
 class ExternalApiInfoException(NzbHydraException):


### PR DESCRIPTION
Exception's message attribute was introduced in Python 2.5 but deprecated with 2.6 and is not present in Python 3+.

I know NzbHydra is not compatible with Python 3 at the moment, but eventually I'd like to have py3 compatibility.