### PR TITLE
Fix config path in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ sudo update-rc.d nzbhydra defaults
 Edit the default configuration options:
 
 ```sh
-sudo nano /etc/defaults/nzbhydra
+sudo nano /etc/default/nzbhydra
 ```
 
 Start the service:


### PR DESCRIPTION
Set the edit configuration path to the same as the one from the cp command.