### PR TITLE
fix omgwtfnzbs timeout

### DIFF
--- a/nzbhydra/searchmodules/omgwtf.py
+++ b/nzbhydra/searchmodules/omgwtf.py
@@ -228,6 +228,10 @@ class OmgWtf(SearchModule):
 
     def get(self, query, timeout=None, cookies=None):
         # overwrite for special handling, e.g. cookies
+        if timeout is None:
+            timeout = self.settings.timeout
+        if timeout is None:
+            timeout = config.settings.searching.timeout
         return requests.get(query, timeout=timeout, verify=False)
 
     def get_ebook_urls(self, search_request):


### PR DESCRIPTION
I noticed that omgwtfnzbs was taking 20-40 seconds to return results and was ignoring the timeout setting.  This seemed to fix it. 