### PR TITLE
SOCKS proxy support

### DIFF
--- a/nzbhydra/socks_proxy.py
+++ b/nzbhydra/socks_proxy.py
@@ -1,0 +1,26 @@
+# coding=utf-8
+
+
+# Module for SOCKS support
+
+# Function to set the SOCKS proxy
+# Returns public IP address via SOCKS proxy (if succesful), None otherwise
+
+def setSOCKSproxy(sockshost,socksport):
+    import socket
+    import urllib2
+
+    try:
+        import socks # Tip: "sudo pip install PySocks"
+    except:
+        print "Python module 'socks' not found. Not setting SOCKS proxy."
+        return None
+    
+    socks.setdefaultproxy(socks.PROXY_TYPE_SOCKS5, sockshost, socksport)
+    socket.socket = socks.socksocket
+
+    try:
+        return urllib2.urlopen('http://ipinfo.io/ip').read().rstrip()
+    except:
+        return None
+


### PR DESCRIPTION
As discussed on https://github.com/theotherp/nzbhydra/issues/279

## Requirements

You need SocksiPy  ("A Python SOCKS client module") installed because of the `import socks`

Suggestions for installation
`sudo apt-get install python-socksipy` (on Ubuntu / Debian)
or
`sudo pip install PySocks`

## Usage:
```
./nzbhydra.py --socksproxy <host>:<port>
```

So, with a TOR SOCKS proxy running:
```
./nzbhydra.py --socksproxy 127.0.0.1:9050
```

With a SOCKS proxy via SSH running on port 1080:
```
./nzbhydra.py --socksproxy 127.0.0.1:1080
```


## Related: Howto setup a SOCKS proxy via SSH on Linux:
```
ssh -D 1080 myaccount@theremotesshserver.blabla.com
```
or just for testing on your Linux:
```
ssh -D 1080 localhost
```

## Logging
Example logging:
```
2016-06-18 09:15:13,810 - NOTICE - nzbhydra - SOCKS settings: host 127.0.0.1 and port 9050
2016-06-18 09:15:14,143 - NOTICE - nzbhydra - Public IP address via SOCKS proxy is 77.247.181.163
```