### PR TITLE
Create nzbhydra.service

### DIFF
--- a/contrib/nzbhydra.service
+++ b/contrib/nzbhydra.service
@@ -1,0 +1,32 @@
+[Unit]
+Description=NZBHydra Daemon
+Documentation=https://github.com/theotherp/nzbhydra
+After=network.target
+
+[Service]
+User=ChangeMe
+Group=ChangeMe
+Type=forking
+#
+# If you're using a Linux distribution that ships with an older version of Python
+# then you'll need to perform an "altinstall" of Python to a version greater then 
+# 2.7.9 but not version 3 - this typically applies to Red Hat based distributions
+# and uncomment out the following line:
+#
+# ExecStart=/usr/local/bin/python2.7 /path-to/nzbhydra/nzbhydra.py --daemon --nobrowser
+#
+# If you're not using a Red Hat based distribution, then you only need to change
+# that path to NZBHydra in the following line:
+#
+ExecStart=python /path-to/nzbhydra/nzbhydra.py --daemon --nobrowser
+# If you're using a Red Hat based distribution then you'll need to comment out the
+# above ExecStart line to avoid service conflicts.
+
+# Change this path to your NZBHydra installation as well
+PIDFile=/path-to/nzbhydra/nzbhydra.pid
+
+KillMode=process
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This systemd service file should work on all Linux distributions that support systemd (which is basically every modern distro of Linux today) - all the end user needs to do is modify the user & group that NZBHydra runs under, and the path to both nzbhydra.py & nzbhydra.pid.

Also included is support for Pythons "altinstall" method of installation, which allows developers to run multiple versions of Python without interfering with the version of Python that shipped with your distribution of choice (mainly helpful for Red Hat based distros)