### PR TITLE
Update nzbhydra.service

### DIFF
--- a/contrib/nzbhydra.service
+++ b/contrib/nzbhydra.service
@@ -6,7 +6,7 @@ After=network.target
 [Service]
 User=ChangeMe
 Group=ChangeMe
-Type=simple
+Type=forking
 #
 # If you're using a Linux distribution that ships with an older version of Python
 # then you'll need to perform an "altinstall" of Python to a version greater then 
@@ -18,7 +18,7 @@ Type=simple
 # If you're not using a Red Hat based distribution, then you only need to change
 # that path to NZBHydra in the following line:
 #
-ExecStart=python /path-to/nzbhydra/nzbhydra.py --nobrowser
+ExecStart=python /path-to/nzbhydra/nzbhydra.py --daemon --nobrowser --pidfile /path-to/nzbhydra/nzbhydra.pid
 # If you're using a Red Hat based distribution then you'll need to comment out the
 # above ExecStart line to avoid service conflicts.
 #
@@ -30,7 +30,7 @@ ExecStart=python /path-to/nzbhydra/nzbhydra.py --nobrowser
 PIDFile=/path-to/nzbhydra/nzbhydra.pid
 
 KillMode=process
-Restart=on-failure
+Restart=on-success
 
 [Install]
 WantedBy=multi-user.target

--- a/contrib/nzbhydra.service
+++ b/contrib/nzbhydra.service
@@ -31,6 +31,7 @@ PIDFile=/path-to/nzbhydra/nzbhydra.pid
 
 KillMode=process
 Restart=on-success
-
+SuccessExitStatus=6
+RestartPreventExitStatus=6
 [Install]
 WantedBy=multi-user.target

--- a/nzbhydra/web.py
+++ b/nzbhydra/web.py
@@ -1316,7 +1316,7 @@ def restart(func=None, afterUpdate=False):
 def shutdown():
     logger.debug("Sending shutdown signal to server")
     sleep(1)
-    os._exit(0)
+    os._exit(6)
 
 
 @app.route("/internalapi/shutdown")

--- a/nzbhydra/web.py
+++ b/nzbhydra/web.py
@@ -1289,7 +1289,7 @@ def triggerRestart():
     func = request.environ.get('werkzeug.server.shutdown')
     if config.settings.main.shutdownForRestart:
         logger.info("Option to shutdown instead of restart is set. Will shutdown and expect external service manager to restart Hydra...")
-        thread = threading.Thread(target=shutdown)
+        thread = threading.Thread(target=shutdownforrestart)
     else:
         thread = threading.Thread(target=restart, args=(func, False))
     thread.daemon = True
@@ -1317,6 +1317,12 @@ def shutdown():
     logger.debug("Sending shutdown signal to server")
     sleep(1)
     os._exit(6)
+
+    
+def shutdownforrestart():
+    logger.debug("Sending restart signal to server")
+    sleep(1)
+    os._exit(0)    
 
 
 @app.route("/internalapi/shutdown")


### PR DESCRIPTION
Made it that systemd always knows the PID even after restart.

You must turn on Shutdown to restart to avoid multiple instances.

Known issues:
Shutdown from the web will restart, must shutdown from systemd.