### PR TITLE
Security improvements: use valid HTTPS where possible

### DIFF
--- a/nzbhydra/infos.py
+++ b/nzbhydra/infos.py
@@ -113,7 +113,7 @@ def imdbid_to_tmdbid(imdbid):
 
 
 def find_series_ids(input):
-    info = webaccess.get("http://api.tvmaze.com/search/shows?q=%s" % input)
+    info = webaccess.get("https://api.tvmaze.com/search/shows?q=%s" % input)
     info.raise_for_status()
     results = []
     for result in info.json():
@@ -138,7 +138,7 @@ def title_from_id(identifier_key, identifier_value):
         if identifier_key == "imdbid":
             if identifier_value[0:2] != "tt":
                 identifier_value = "tt%s" % identifier_value
-            url = furl("http://www.omdbapi.com").add({"i": identifier_value, "plot": "short", "r": "json"}).tostr()
+            url = furl("https://www.omdbapi.com").add({"i": identifier_value, "plot": "short", "r": "json"}).tostr()
             omdb = webaccess.get(url)
             return omdb.json()["Title"]
 
@@ -146,7 +146,7 @@ def title_from_id(identifier_key, identifier_value):
             raise AttributeError("Unknown identifier %s" % identifier_key)
 
         tvmaze_key = "tvrage" if identifier_key == "rid" else "thetvdb"
-        tvmaze = webaccess.get(furl("http://api.tvmaze.com/lookup/shows").add({tvmaze_key: identifier_value}).url)
+        tvmaze = webaccess.get(furl("https://api.tvmaze.com/lookup/shows").add({tvmaze_key: identifier_value}).url)
         if tvmaze.status_code == 404:
             #Unfortunately TVMaze returns a 404 for unknown/invalid IDs
             raise ExternalApiInfoException("Unable to find id %s and value %s at TVMaze" % (identifier_key, identifier_value))

--- a/nzbhydra/socks_proxy.py
+++ b/nzbhydra/socks_proxy.py
@@ -20,7 +20,7 @@ def setSOCKSproxy(sockshost,socksport):
     socket.socket = socks.socksocket
 
     try:
-        return urllib2.urlopen('http://ipinfo.io/ip').read().rstrip()
+        return urllib2.urlopen('https://ipinfo.io/ip').read().rstrip()
     except:
         return None
 

--- a/nzbhydra/webaccess.py
+++ b/nzbhydra/webaccess.py
@@ -32,10 +32,10 @@ def getCleanProxyUrl(url):
 def get(url, **kwargs):
     global proxies
     myproxies = proxies if proxies is not None and furl(url).host not in ["127.0.0.1", "localhost"] and "192.168" not in str(url) else None
-    return requests.get(url, proxies=myproxies, verify=False, **kwargs)
+    return requests.get(url, proxies=myproxies, **kwargs)
 
 
 def post(url, **kwargs):
     global proxies
     myproxies = proxies if proxies is not None and furl(url).host not in ["127.0.0.1", "localhost"] and "192.168" not in str(url) else None
-    return requests.post(url, proxies=myproxies, verify=False, **kwargs)
+    return requests.post(url, proxies=myproxies, **kwargs)


### PR DESCRIPTION
These minor changes use valid HTTPS for outgoing connections to different services or web requests in general.  The different APIs are available over HTTPS now (including ipinfo which allows its IP lookup @ https://ipinfo.io/ip for free).

As for the general `webaccess.get` and `webaccess.post`, verifying TLS/SSL ensures that the connection is secured, avoiding man in the middle attacks or otherwise connecting to a service with any form of invalid cert.  This makes for better standard security overall.

I see that #138 exists but if a device's SSL is broken or old that it can't connect to a valid https:// address, then there's a lot wrong with the device/system.  If broken SSL implementations had to be supported, then another option could be to add a "Don't verify SSL" option to the settings (eg how SABnzbd does it).  In that case, the default should be to always verify and maybe add a warning message in the UI against disabling the setting. 



