### PR TITLE
better usage of furl for username and password

### DIFF
--- a/nzbhydra/downloader.py
+++ b/nzbhydra/downloader.py
@@ -58,7 +58,9 @@ class Nzbget(Downloader):
         f.scheme = "https" if ssl else "http"
         f.port = port
         if username is not None and password is not None:
-            f.path.add("%s:%s" % (username, password))
+            #f.path.add("%s:%s" % (username, password))
+            f.username = username
+            f.password = password
         f.path.add("xmlrpc")
 
         return xmlrpc.client.ServerProxy(f.tostr())


### PR DESCRIPTION
I adapted the code followinf furl library usage.
the username and password should be in their on object : f.username and f.password.

this solves the problem of password with special caracters ont being passed to nzbget correctly.