### PR TITLE
Unicode issue for anizb

### DIFF
--- a/nzbhydra/searchmodules/anizb.py
+++ b/nzbhydra/searchmodules/anizb.py
@@ -75,7 +75,7 @@ class Anizb(SearchModule):
         entries = []
         countRejected = self.getRejectedCountDict()
         try:
-            tree = ET.fromstring(xml)
+            tree = ET.fromstring(xml.encode('utf-8'))
         except Exception:
             self.exception("Error parsing XML: %s..." % xml[:500])
             logger.debug(xml)


### PR DESCRIPTION
The fromstring method of ElementTree does not support unicode string therefore it has to be encoded before passing in.